### PR TITLE
Added installation step for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-2.1.1/macos.sh |
 curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-2.1.1/deb.sh | sh
 ```
 
+### FreeBSD
+
+```bash
+cd /usr/ports/net/ipinfo-cli && make install clean
+```
+
 OR
 
 ```bash


### PR DESCRIPTION
Hi,

I maintain the ipinfo-cli package on FreeBSD. If you want, I added an installation step in the README.

https://www.freshports.org/net/ipinfo-cli/

Thanks