### PR TITLE
Added cidr2ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Replace `<path>` with the required location.
 
 ## Additional CLIs
 
-The `ipinfo` CLI has some subcommands like `grepip`, `cidr2range`,
+The `ipinfo` CLI has some subcommands like `grepip`, `cidr2range`, `cidr2ip`,
 `range2cidr` and `range2ip` which are also shipped as standalone binaries.
 
 These binaries are available via all the **same installation methods** as
@@ -147,6 +147,7 @@ Currently these subcommands are separately shipped:
 | ---------- | ------- |
 | grepip     | [1.2.0](https://github.com/ipinfo/cli/releases/tag/grepip-1.2.0) |
 | cidr2range | [1.2.0](https://github.com/ipinfo/cli/releases/tag/cidr2range-1.2.0) |
+| cidr2ip    | [1.0.0](https://github.com/ipinfo/cli/releases/tag/cidr2ip-1.0.0) |
 | range2cidr | [1.2.0](https://github.com/ipinfo/cli/releases/tag/range2cidr-1.2.0) |
 | range2ip   | [1.0.0](https://github.com/ipinfo/cli/releases/tag/range2ip-1.0.0) |
 

--- a/cidr2ip/build-all-platforms.sh
+++ b/cidr2ip/build-all-platforms.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Build binary for all platforms for version $1.
+
+set -e
+
+DIR=`dirname $0`
+ROOT=$DIR/..
+
+VSN=$1
+
+$ROOT/scripts/build-all-platforms.sh "cidr2ip" $VSN

--- a/cidr2ip/build.sh
+++ b/cidr2ip/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Build local binary.
+
+set -e
+
+DIR=`dirname $0`
+ROOT=$DIR/..
+
+$ROOT/scripts/build.sh "cidr2ip"

--- a/cidr2ip/completions.go
+++ b/cidr2ip/completions.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/ipinfo/cli/lib/complete"
+	"github.com/ipinfo/cli/lib/complete/predict"
+)
+
+var completions = &complete.Command{
+	Flags: map[string]complete.Predictor{
+		"-v":                    predict.Nothing,
+		"--version":             predict.Nothing,
+		"-h":                    predict.Nothing,
+		"--help":                predict.Nothing,
+		"--completions-install": predict.Nothing,
+		"--completions-bash":    predict.Nothing,
+		"--completions-zsh":     predict.Nothing,
+		"--completions-fish":    predict.Nothing,
+	},
+}
+
+func handleCompletions() {
+	completions.Complete(progBase)
+}

--- a/cidr2ip/deb.sh
+++ b/cidr2ip/deb.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+VSN=1.0.0
+
+curl -LO https://github.com/ipinfo/cli/releases/download/cidr2ip-${VSN}/cidr2ip_${VSN}.deb
+sudo dpkg -i cidr2ip_${VSN}.deb
+rm cidr2ip_${VSN}.deb
+
+echo
+echo 'You can now run `cidr2ip`'.
+
+if [ -f "$0" ]; then
+    rm $0
+fi

--- a/cidr2ip/dist/DEBIAN/control
+++ b/cidr2ip/dist/DEBIAN/control
@@ -8,4 +8,4 @@ Vcs-browser: https://github.com/ipinfo/cli
 Homepage: https://ipinfo.io
 Package: cidr2ip
 Architecture: amd64
-Description: A simple tool for converting from CIDRs to to individual IPs within those CIDR.
+Description: A simple tool for converting from CIDRs to to individual IPs within those CIDRs.

--- a/cidr2ip/dist/DEBIAN/control
+++ b/cidr2ip/dist/DEBIAN/control
@@ -1,0 +1,11 @@
+Source: cidr2ip
+Section: utils
+Version: 1.0.0
+Priority: optional
+Maintainer: IPinfo <support@ipinfo.io>
+Vcs-Git: https://github.com/ipinfo/cli
+Vcs-browser: https://github.com/ipinfo/cli
+Homepage: https://ipinfo.io
+Package: cidr2ip
+Architecture: amd64
+Description: A simple tool for converting from CIDRs to to individual IPs within those CIDR.

--- a/cidr2ip/macos.sh
+++ b/cidr2ip/macos.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+VSN=1.0.0
+PLAT=darwin_amd64
+
+curl -LO https://github.com/ipinfo/cli/releases/download/cidr2ip-${VSN}/cidr2ip_${VSN}_${PLAT}.tar.gz
+tar -xf cidr2ip_${VSN}_${PLAT}.tar.gz
+rm cidr2ip_${VSN}_${PLAT}.tar.gz
+mv cidr2ip_${VSN}_${PLAT} /usr/local/bin/cidr2ip
+
+echo
+echo 'You can now run `cidr2ip`'.
+
+if [ -f "$0" ]; then
+    rm $0
+fi

--- a/cidr2ip/main.go
+++ b/cidr2ip/main.go
@@ -22,7 +22,7 @@ Description:
   Accepts CIDRs and file paths to files containing CIDRs, converting
   them all to individual IPs within those CIDRs.
 	  
-	$ %[1]s 8.8.8.0/24
+  $ %[1]s 8.8.8.0/24
 
 Options:
   General:

--- a/cidr2ip/main.go
+++ b/cidr2ip/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fatih/color"
+	"github.com/ipinfo/cli/lib"
+	"github.com/ipinfo/cli/lib/complete/install"
+	"github.com/spf13/pflag"
+)
+
+var progBase = filepath.Base(os.Args[0])
+var version = "1.0.0"
+
+func printHelp() {
+	fmt.Printf(
+		`Usage: %s [<opts>] <cidrs | filepath>
+
+Description:
+	Accepts CIDRs and file paths to files containing CIDRs, converting
+	them all to individual IPs within those CIDRs.
+	  
+	$ %[1]s 8.8.8.0/24
+
+Options:
+  General:
+    --version, -v
+      show binary release number.
+    --help, -h
+      show help.
+
+  Completions:
+    --completions-install
+      attempt completions auto-installation for any supported shell.
+    --completions-bash
+      output auto-completion script for bash for manual installation.
+    --completions-zsh
+      output auto-completion script for zsh for manual installation.
+    --completions-fish
+      output auto-completion script for fish for manual installation.
+`, progBase)
+}
+
+func cmd() error {
+	var fVsn bool
+	var fCompletionsInstall bool
+	var fCompletionsBash bool
+	var fCompletionsZsh bool
+	var fCompletionsFish bool
+
+	f := lib.CmdCIDR2IPFlags{}
+	f.Init()
+	pflag.BoolVarP(
+		&fVsn,
+		"version", "v", false,
+		"print binary release number.",
+	)
+	pflag.BoolVarP(
+		&fCompletionsInstall,
+		"completions-install", "", false,
+		"attempt completions auto-installation for any supported shell.",
+	)
+	pflag.BoolVarP(
+		&fCompletionsBash,
+		"completions-bash", "", false,
+		"output auto-completion script for bash for manual installation.",
+	)
+	pflag.BoolVarP(
+		&fCompletionsZsh,
+		"completions-zsh", "", false,
+		"output auto-completion script for zsh for manual installation.",
+	)
+	pflag.BoolVarP(
+		&fCompletionsFish,
+		"completions-fish", "", false,
+		"output auto-completion script for fish for manual installation.",
+	)
+	pflag.Parse()
+
+	if fVsn {
+		fmt.Println(version)
+		return nil
+	}
+
+	if fCompletionsInstall {
+		return install.Install(progBase)
+	}
+	if fCompletionsBash {
+		installStr, err := install.BashCmd(progBase)
+		if err != nil {
+			return err
+		}
+		fmt.Println(installStr)
+		return nil
+	}
+	if fCompletionsZsh {
+		installStr, err := install.ZshCmd(progBase)
+		if err != nil {
+			return err
+		}
+		fmt.Println(installStr)
+		return nil
+	}
+	if fCompletionsFish {
+		installStr, err := install.FishCmd(progBase)
+		if err != nil {
+			return err
+		}
+		fmt.Println(installStr)
+		return nil
+	}
+
+	return lib.CmdCIDR2IP(f, pflag.Args(), printHelp)
+}
+
+func main() {
+	// obey NO_COLOR env var.
+	if os.Getenv("NO_COLOR") != "" {
+		color.NoColor = true
+	}
+
+	handleCompletions()
+
+	if err := cmd(); err != nil {
+		fmt.Printf("err: %v\n", err)
+	}
+}

--- a/cidr2ip/main.go
+++ b/cidr2ip/main.go
@@ -19,8 +19,8 @@ func printHelp() {
 		`Usage: %s [<opts>] <cidrs | filepath>
 
 Description:
-	Accepts CIDRs and file paths to files containing CIDRs, converting
-	them all to individual IPs within those CIDRs.
+  Accepts CIDRs and file paths to files containing CIDRs, converting
+  them all to individual IPs within those CIDRs.
 	  
 	$ %[1]s 8.8.8.0/24
 

--- a/cidr2ip/release.sh
+++ b/cidr2ip/release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Build and upload (to GitHub) for all platforms for version $1.
+
+set -e
+
+DIR=`dirname $0`
+ROOT=$DIR/..
+
+VSN=$1
+
+$ROOT/scripts/release.sh "cidr2ip" $VSN

--- a/ipinfo/cmd_cidr2ip.go
+++ b/ipinfo/cmd_cidr2ip.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ipinfo/cli/lib"
+	"github.com/ipinfo/cli/lib/complete"
+	"github.com/ipinfo/cli/lib/complete/predict"
+	"github.com/spf13/pflag"
+)
+
+var completionsCIDR2IP = &complete.Command{
+	Flags: map[string]complete.Predictor{
+		"-h":     predict.Nothing,
+		"--help": predict.Nothing,
+	},
+}
+
+func printHelpCIDR2IP() {
+	fmt.Printf(
+		`Usage: %s cidr2ip [<opts>] <cidrs | filepath>
+
+Description:
+  Accepts CIDRs and file paths to files containing CIDRs, converting
+  them all to individual IPs within those CIDRs.
+
+  $ %[1]s cidr2ip 8.8.8.0/24
+
+Options:
+  --help, -h
+    show help.
+`, progBase)
+}
+
+func cmdCIDR2IP() error {
+	f := lib.CmdCIDR2IPFlags{}
+	f.Init()
+	pflag.Parse()
+
+	return lib.CmdCIDR2IP(f, pflag.Args()[1:], printHelpCIDR2IP)
+}

--- a/ipinfo/cmd_default.go
+++ b/ipinfo/cmd_default.go
@@ -26,6 +26,7 @@ Commands:
   prips       print IP list from CIDR or range.
   grepip      grep for IPs matching criteria from any source.
   cidr2range  convert CIDRs to IP ranges.
+  cidr2ip     convert CIDRs to individual IPs within those CIDRs.
   range2cidr  convert IP ranges to CIDRs.
   range2ip    convert IP ranges to individual IPs within those ranges.
   cache       manage the cache.

--- a/ipinfo/completions.go
+++ b/ipinfo/completions.go
@@ -14,6 +14,7 @@ var completions = &complete.Command{
 		"prips":      completionsPrips,
 		"grepip":     completionsGrepIP,
 		"cidr2range": completionsCIDR2Range,
+		"cidr2ip":    completionsCIDR2IP,
 		"range2cidr": completionsRange2CIDR,
 		"range2ip":   completionsRange2IP,
 		"cache":      completionsCache,

--- a/ipinfo/main.go
+++ b/ipinfo/main.go
@@ -55,6 +55,8 @@ func main() {
 		err = cmdGrepIP()
 	case cmd == "cidr2range":
 		err = cmdCIDR2Range()
+	case cmd == "cidr2ip":
+		err = cmdCIDR2IP()
 	case cmd == "range2cidr":
 		err = cmdRange2CIDR()
 	case cmd == "range2ip":

--- a/lib/cmd_cidr2ip.go
+++ b/lib/cmd_cidr2ip.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// CmdCIDR2IPFlags are flags expected by CmdCIDR2IP.
+type CmdCIDR2IPFlags struct {
+	Help bool
+}
+
+// Init initializes the common flags available to CmdCIDR2IP with sensible
+// defaults.
+//
+// pflag.Parse() must be called to actually use the final flag values.
+func (f *CmdCIDR2IPFlags) Init() {
+	pflag.BoolVarP(
+		&f.Help,
+		"help", "h", false,
+		"show help.",
+	)
+}
+
+func CmdCIDR2IP(f CmdCIDR2IPFlags, args []string, printHelp func()) error {
+	if f.Help {
+		printHelp()
+		return nil
+	}
+
+	// require args and/or stdin.
+	stat, _ := os.Stdin.Stat()
+	isStdin := (stat.Mode() & os.ModeCharDevice) == 0
+	if len(args) == 0 && !isStdin {
+		printHelp()
+		return nil
+	}
+
+	return IPListWriteFrom(args, true, false, false, true, true)
+}

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -11,4 +11,5 @@ gofmt -w                                                                      \
     $ROOT/grepip                                                              \
     $ROOT/cidr2range                                                          \
     $ROOT/range2cidr                                                          \
-    $ROOT/range2ip
+    $ROOT/range2ip                                                            \
+    $ROOT/cidr2ip

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,4 +8,5 @@ golint                                                                        \
     ./grepip/...                                                              \
     ./cidr2range/...                                                          \
     ./range2cidr/...                                                          \
-    ./range2ip/...
+    ./range2ip/...                                                            \
+    ./cidr2ip/...


### PR DESCRIPTION
Added cidr2ip that accepts CIDRs and file paths to files containing CIDRs, converting them all to individual IPs within those ranges.
`Usage : $ ipinfo cidr2ip 8.8.8.0/24`
```bash 
$ ./ipinfo cidr2ip 8.8.8.0/30
8.8.8.0
8.8.8.1
8.8.8.2
8.8.8.3 
```