### PR TITLE
Adding installation step for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ docker run ipinfo/ipinfo:2.7.0
 cd /usr/ports/net/ipinfo-cli && make install clean
 ```
 
+### Arch linux
+
+```bash
+git clone https://aur.archlinux.org/ipinfo-cli.git
+makepkg -si
+```
+
 OR
 
 ```bash


### PR DESCRIPTION
Hi, guys!

I maintain the ipinfo-cli package on AUR - Arch Linux. If you want, I added an installation step in the README.
