### PR TITLE
Replacing go get with go install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ iwr -useb https://github.com/ipinfo/cli/releases/download/ipinfo-2.7.0/windows.p
 docker run ipinfo/ipinfo:2.7.0
 ```
 
-### Using `go get`
+### Using `go install`
 
 Make sure that `$GOPATH/bin` is in your `$PATH`, because that's where this gets
 installed:
 
 ```bash
-go get github.com/ipinfo/cli/ipinfo
+go install github.com/ipinfo/cli/ipinfo@latest
 ```
 
 ### Using `curl`/`wget`


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install is the recommended way of installing executables - https://go.dev/doc/go-get-install-deprecation

This merge request adds command that uses go install to install ipinfo cli as a command and works across Go versions.