### PR TITLE
incl root flags in auto-completion along with subcommands

### DIFF
--- a/ipinfo/completions.go
+++ b/ipinfo/completions.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/ipinfo/cli/lib/complete"
+	"github.com/ipinfo/cli/lib/complete/predict"
 )
 
 var completions = &complete.Command{
@@ -25,10 +26,12 @@ var completions = &complete.Command{
 		"config":     completionsConfig,
 		"completion": completionsCompletion,
 		"version":    completionsVersion,
-		"-v":         nil,
-		"--version":  nil,
-		"-h":         nil,
-		"--help":     nil,
+	},
+	Flags: map[string]complete.Predictor{
+		"-v":        predict.Nothing,
+		"--version": predict.Nothing,
+		"-h":        predict.Nothing,
+		"--help":    predict.Nothing,
 	},
 }
 

--- a/ipinfo/completions.go
+++ b/ipinfo/completions.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/ipinfo/cli/lib/complete"
-	"github.com/ipinfo/cli/lib/complete/predict"
 )
 
 var completions = &complete.Command{
@@ -26,12 +25,10 @@ var completions = &complete.Command{
 		"config":     completionsConfig,
 		"completion": completionsCompletion,
 		"version":    completionsVersion,
-	},
-	Flags: map[string]complete.Predictor{
-		"-v":        predict.Nothing,
-		"--version": predict.Nothing,
-		"-h":        predict.Nothing,
-		"--help":    predict.Nothing,
+		"-v":         nil,
+		"--version":  nil,
+		"-h":         nil,
+		"--help":     nil,
 	},
 }
 

--- a/lib/complete/complete.go
+++ b/lib/complete/complete.go
@@ -133,6 +133,9 @@ reset:
 		return c.suggestLeafCommandOptions(), nil
 	case !arg.Completed:
 		// Currently typing a sub command.
+		if arg.HasFlag {
+			return c.suggestLeafCommandOptions(), nil
+		}
 		return c.suggestSubCommands(arg.Text), nil
 	case c.SubCmdGet(arg.Text) != nil:
 		// Sub command completed, look into that sub command completion.


### PR DESCRIPTION
The flag predictor is not working along with complete. Strangely either complete works or predict. But do not work simultaneously.
That is why, I have fixed the issue with `complete`.