### PR TITLE
ipinfo grepip exclude bogon error

### DIFF
--- a/lib/cmd_grepip.go
+++ b/lib/cmd_grepip.go
@@ -168,7 +168,7 @@ func CmdGrepIP(
 					mIPStr := d[m[0]:m[1]]
 					mIP := net.ParseIP(mIPStr)
 					if mIP == nil {
-						return
+						goto next_match
 					}
 					if strings.Contains(mIPStr, ":") {
 						ip, _ := IP6FromStdIP(mIP.To16())

--- a/lib/cmd_grepip.go
+++ b/lib/cmd_grepip.go
@@ -167,6 +167,9 @@ func CmdGrepIP(
 				for _, m := range allMatches {
 					mIPStr := d[m[0]:m[1]]
 					mIP := net.ParseIP(mIPStr)
+					if mIP == nil {
+						return
+					}
 					if strings.Contains(mIPStr, ":") {
 						ip, _ := IP6FromStdIP(mIP.To16())
 						for _, r := range bogonIP6List {


### PR DESCRIPTION
I was able to resolve the issue by checking the result of `net.ParseIP()`. It is working fine now