### PR TITLE
fix: ipinfo login

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ will not be available. Get your token for free at
 [https://ipinfo.io/signup](https://ipinfo.io/signup?ref=cli).
 
 ```bash
-ipinfo login
+ipinfo init
 ```
 
 ### My IP

--- a/ipinfo/cmd_asn.go
+++ b/ipinfo/cmd_asn.go
@@ -84,7 +84,7 @@ func cmdASN(asn string) error {
 
 	// require token for ASN API.
 	if ii.Token == "" {
-		return errors.New("ASN lookups require a token; login via `ipinfo login`.")
+		return errors.New("ASN lookups require a token; login via `ipinfo init`.")
 	}
 
 	data, err := ii.GetASNDetails(asn)

--- a/ipinfo/cmd_bulk.go
+++ b/ipinfo/cmd_bulk.go
@@ -120,7 +120,7 @@ func cmdBulk() (err error) {
 
 	// require token for bulk.
 	if ii.Token == "" {
-		return errors.New("bulk lookups require a token; login via `ipinfo login`.")
+		return errors.New("bulk lookups require a token; login via `ipinfo init`.")
 	}
 
 	data, err := ii.GetIPInfoBatch(ips, ipinfo.BatchReqOpts{

--- a/ipinfo/cmd_default.go
+++ b/ipinfo/cmd_default.go
@@ -127,7 +127,7 @@ func cmdDefault() (err error) {
 
 	// require token for bulk.
 	if ii.Token == "" {
-		return errors.New("bulk lookups require a token; login via `ipinfo login`.")
+		return errors.New("bulk lookups require a token; login via `ipinfo init`.")
 	}
 
 	data, err := ii.GetIPInfoBatch(ips, ipinfo.BatchReqOpts{

--- a/ipinfo/cmd_download.go
+++ b/ipinfo/cmd_download.go
@@ -89,7 +89,7 @@ func cmdDownload() error {
 
 	// require token for download.
 	if token == "" {
-		return errors.New("downloading requires a token; login via `ipinfo login` or pass the `--token` argument")
+		return errors.New("downloading requires a token; login via `ipinfo init` or pass the `--token` argument")
 	}
 
 	// get download format and extension.


### PR DESCRIPTION
Unless I'm mistaken, `ipinfo login` is not a valid command in the current CLI. `ipinfo init` seems to be used instead. Updated messages to reflect that.

- ipinfo login is deprecated/invalid in latest version of cli
