### PR TITLE
Updating PPA release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install ipinfo-cli
 OR to install the latest `amd64` version without automatic updates:
 
 ```bash
-curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.1/macos.sh | sh
+curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.2/macos.sh | sh
 ```
 
 ### Ubuntu PPA
@@ -43,14 +43,14 @@ _Note_: this is a one-time installation; updates are not automatic. Use the PPA
 for automatic updates.
 
 ```bash
-curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.1/deb.sh | sh
+curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.2/deb.sh | sh
 ```
 
 OR
 
 ```bash
-curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.1/ipinfo_3.0.1.deb
-sudo dpkg -i ipinfo_3.0.1.deb
+curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.2/ipinfo_3.0.2.deb
+sudo dpkg -i ipinfo_3.0.2.deb
 ```
 
 ### FreeBSD
@@ -71,7 +71,7 @@ makepkg -si
 _Note_: run powershell as administrator before executing this command.
 
 ```bash
-iwr -useb https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.1/windows.ps1 | iex
+iwr -useb https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.2/windows.ps1 | iex
 ```
 
 ### Scoop
@@ -83,7 +83,7 @@ scoop install ipinfo-cli
 ### Docker
 
 ```bash
-docker run --rm -it ipinfo/ipinfo:3.0.1
+docker run --rm -it ipinfo/ipinfo:3.0.2
 ```
 
 To save the CLI's config, add `-v "/path_to_config:/root/.config/ipinfo"`. For
@@ -91,7 +91,7 @@ example, the following command saves the config to the `ipinfo` directory in
 the current working directory.
 
 ```bash
-docker run --rm -it -v "$PWD/ipinfo:/root/.config/ipinfo" ipinfo/ipinfo:3.0.1
+docker run --rm -it -v "$PWD/ipinfo:/root/.config/ipinfo" ipinfo/ipinfo:3.0.2
 ```
 
 ### Using `go install`
@@ -142,12 +142,12 @@ After choosing a platform `PLAT` from above, run:
 
 ```bash
 # for Windows, use ".zip" instead of ".tar.gz"
-curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.1/ipinfo_3.0.1_${PLAT}.tar.gz
+curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.2/ipinfo_3.0.2_${PLAT}.tar.gz
 # OR
-wget https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.1/ipinfo_3.0.1_${PLAT}.tar.gz
+wget https://github.com/ipinfo/cli/releases/download/ipinfo-3.0.2/ipinfo_3.0.2_${PLAT}.tar.gz
 
-tar -xvf ipinfo_3.0.1_${PLAT}.tar.gz
-mv ipinfo_3.0.1_${PLAT} /usr/local/bin/ipinfo
+tar -xvf ipinfo_3.0.2_${PLAT}.tar.gz
+mv ipinfo_3.0.2_${PLAT} /usr/local/bin/ipinfo
 ```
 
 ### Using `git`

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-ipinfo (3.0.1) focal; urgency=medium
+ipinfo (3.0.2) focal; urgency=medium
 
-  * 3.0.1 release.
+  * 3.0.2 release.
 
- -- umar <support@ipinfo.io>  Mon, 22 Nov 2021 12:32:18 +0500
+ -- usama <usama@ipinfo.io>  Mon, 07 Aug 2023 12:36:18 +0500

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ ipinfo (3.0.2) focal; urgency=medium
 
   * 3.0.2 release.
 
- -- usama <usama@ipinfo.io>  Mon, 07 Aug 2023 12:36:18 +0500
+ -- usama <support@ipinfo.io>  Mon, 07 Aug 2023 12:36:18 +0500

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,11 @@
 Source: ipinfo
+Standards-Version: 4.6.2
 Maintainer: IPinfo <support@ipinfo.io>
 Section: utils
 Priority: optional
 Build-Depends: debhelper-compat (= 12),
                dh-golang,
-               golang-1.16
+               golang-1.18
 Vcs-Git: https://github.com/ipinfo/cli
 Vcs-browser: https://github.com/ipinfo/cli
 Homepage: https://ipinfo.io

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,1 @@
-ipinfo_3.0.1_source.buildinfo utils optional
+ipinfo_3.0.2_source.buildinfo utils optional

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,3 @@
 #!/usr/bin/make -f
 %:
-	PATH=${PATH}:/usr/lib/go-1.16/bin dh $@ --builddirectory=_build --buildsystem=golang --with=golang
-	
+	PATH=${PATH}:/usr/lib/go-1.18/bin dh $@ --builddirectory=_build --buildsystem=golang --with=golang

--- a/ipinfo/deb.sh
+++ b/ipinfo/deb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VSN=3.0.1
+VSN=3.0.2
 
 curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-${VSN}/ipinfo_${VSN}.deb
 sudo dpkg -i ipinfo_${VSN}.deb

--- a/ipinfo/main.go
+++ b/ipinfo/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var progBase = filepath.Base(os.Args[0])
-var version = "3.0.1"
+var version = "3.0.2"
 
 // global flags.
 var fHelp bool

--- a/ipinfo/windows.ps1
+++ b/ipinfo/windows.ps1
@@ -1,4 +1,4 @@
-$VSN = "3.0.1"
+$VSN = "3.0.2"
 
 # build the filename for the Zip archive and exe file
 $FileName = "ipinfo_$($VSN)_windows_amd64"

--- a/scripts/release-ppa.sh
+++ b/scripts/release-ppa.sh
@@ -18,13 +18,13 @@ if [ -z "$KEY" ]; then
     exit 1
 fi
 
-# building the package package 
+# building the package
 cd $ROOT
-debuild -us -uc -S -d 
+debuild -us -uc -S -d
 
 # signing the package
 cd $ROOT/..
 debsign -k $KEY ipinfo_${VSN}.dsc ipinfo_${VSN}_source.changes
 
-# uploading the package to ppa 
+# uploading the package to ppa
 dput ppa:ipinfo/ppa ipinfo_${VSN}_source.changes


### PR DESCRIPTION
Updated release script to use Golang version `1.18` instead of `1.16`.