### PR TITLE
Handle adjacent prefixes in ipinfo tool aggregate

### DIFF
--- a/ipinfo/cmd_tool_aggregate.go
+++ b/ipinfo/cmd_tool_aggregate.go
@@ -23,9 +23,7 @@ func printHelpToolAggregate() {
 		`Usage: %s tool aggregate [<opts>] <cidr | ip | ip-range | filepath>
 
 Description:
-  Accepts IPs, IP ranges, and CIDRs, aggregating them efficiently.
-  Input can be IPs, IP ranges, CIDRs, and/or filepath to a file
-  containing any of these. Works for IPv4 only.
+  Accepts IPv4 IPs and CIDRs, aggregating them efficiently.
 
   If input contains single IPs, it tries to merge them into the input CIDRs,
   otherwise they are printed to the output as they are.
@@ -36,9 +34,6 @@ Description:
 Examples:
   # Aggregate two CIDRs.
   $ %[1]s tool aggregate 1.1.1.0/30 1.1.1.0/28
-
-  # Aggregate IP range and CIDR.
-  $ %[1]s tool aggregate 1.1.1.0-1.1.1.244 1.1.1.0/28
 
   # Aggregate enteries from 2 files.
   $ %[1]s tool aggregate /path/to/file1.txt /path/to/file2.txt

--- a/ipinfo/cmd_tool_aggregate.go
+++ b/ipinfo/cmd_tool_aggregate.go
@@ -25,7 +25,7 @@ func printHelpToolAggregate() {
 Description:
   Accepts IPs, IP ranges, and CIDRs, aggregating them efficiently.
   Input can be IPs, IP ranges, CIDRs, and/or filepath to a file
-  containing any of these. Works for both IPv4 and IPv6.
+  containing any of these. Works for IPv4 only.
 
   If input contains single IPs, it tries to merge them into the input CIDRs,
   otherwise they are printed to the output as they are.

--- a/lib/cidr.go
+++ b/lib/cidr.go
@@ -1,0 +1,68 @@
+package lib
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"net"
+	"sort"
+)
+
+// CIDR represens a Classless Inter-Domain Routing structure.
+type CIDR struct {
+	IP      net.IP
+	Network *net.IPNet
+}
+
+// newCidr creates a newCidr CIDR structure.
+func newCidr(s string) *CIDR {
+	ip, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return &CIDR{
+		IP:      ip,
+		Network: ipnet,
+	}
+}
+
+func (c *CIDR) String() string {
+	return c.Network.String()
+}
+
+// MaskLen returns a network mask length.
+func (c *CIDR) MaskLen() uint32 {
+	i, _ := c.Network.Mask.Size()
+	return uint32(i)
+}
+
+// PrefixUint32 returns a prefix.
+func (c *CIDR) PrefixUint32() uint32 {
+	return binary.BigEndian.Uint32(c.IP.To4())
+}
+
+// Size returns a size of a CIDR range.
+func (c *CIDR) Size() int {
+	ones, bits := c.Network.Mask.Size()
+	return int(math.Pow(2, float64(bits-ones)))
+}
+
+// list returns a slice of sorted CIDR structures.
+func list(s []string) []*CIDR {
+	out := make([]*CIDR, 0)
+	for _, c := range s {
+		out = append(out, newCidr(c))
+	}
+	sort.Sort(cidrSort(out))
+	return out
+}
+
+type cidrSort []*CIDR
+
+func (s cidrSort) Len() int      { return len(s) }
+func (s cidrSort) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s cidrSort) Less(i, j int) bool {
+	cmp := bytes.Compare(s[i].IP, s[j].IP)
+	return cmp < 0 || (cmp == 0 && s[i].MaskLen() < s[j].MaskLen())
+}

--- a/lib/cmd_tool_aggregate.go
+++ b/lib/cmd_tool_aggregate.go
@@ -200,9 +200,29 @@ func CmdToolAggregate(
 
 	// Combine adjacent entries.
 	adjacentCombined := combineAdjacent(merged)
+	outlierIPs := make([]net.IP, 0)
+	length := len(adjacentCombined)
+	if length != 0 {
+		for _, ip := range parsedIPs {
+			for i, cidr := range adjacentCombined {
+				if cidr.Contains(ip) {
+					break
+				} else if i == length-1 {
+					outlierIPs = append(outlierIPs, ip)
+				}
+			}
+		}
+	} else {
+		outlierIPs = append(outlierIPs, parsedIPs...)
+	}
 
 	// Print the aggregated CIDRs.
 	for _, r := range adjacentCombined {
+		fmt.Println(r.String())
+	}
+
+	// Print the outlierIPs.
+	for _, r := range outlierIPs {
 		fmt.Println(r.String())
 	}
 

--- a/lib/cmd_tool_aggregate.go
+++ b/lib/cmd_tool_aggregate.go
@@ -67,51 +67,17 @@ func CmdToolAggregate(
 	parseInput := func(rows []string) ([]string, []net.IP) {
 		parsedCIDRs := make([]string, 0)
 		parsedIPs := make([]net.IP, 0)
-		var separator string
 		for _, rowStr := range rows {
 			if strings.ContainsAny(rowStr, ",-") {
-				if delim := strings.ContainsRune(rowStr, ','); delim {
-					separator = ","
-				} else {
-					separator = "-"
-				}
-
-				ipRange := strings.Split(rowStr, separator)
-				if len(ipRange) != 2 {
-					if !f.Quiet {
-						fmt.Printf("Invalid IP range: %s\n", rowStr)
-					}
-					continue
-				}
-
-				if strings.ContainsRune(rowStr, ':') {
-					cidrs, err := CIDRsFromIP6RangeStrRaw(rowStr)
-					if err == nil {
-						parsedCIDRs = append(parsedCIDRs, cidrs...)
-						continue
-					} else {
-						if !f.Quiet {
-							fmt.Printf("Invalid IP range %s. Err: %v\n", rowStr, err)
-						}
-						continue
-					}
-				} else {
-					cidrs, err := CIDRsFromIPRangeStrRaw(rowStr)
-					if err == nil {
-						parsedCIDRs = append(parsedCIDRs, cidrs...)
-						continue
-					} else {
-						if !f.Quiet {
-							fmt.Printf("Invalid IP range %s. Err: %v\n", rowStr, err)
-						}
-						continue
-					}
-				}
+				continue
 			} else if strings.ContainsRune(rowStr, '/') {
-				parsedCIDRs = append(parsedCIDRs, []string{rowStr}...)
+				_, ipnet, err := net.ParseCIDR(rowStr)
+				if err == nil && IsCIDRIPv4(ipnet) {
+					parsedCIDRs = append(parsedCIDRs, []string{rowStr}...)
+				}
 				continue
 			} else {
-				if ip := net.ParseIP(rowStr); ip != nil {
+				if ip := net.ParseIP(rowStr); IsIPv4(ip) {
 					parsedIPs = append(parsedIPs, ip)
 				} else {
 					if !f.Quiet {

--- a/lib/cmd_tool_aggregate.go
+++ b/lib/cmd_tool_aggregate.go
@@ -2,14 +2,10 @@ package lib
 
 import (
 	"bufio"
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -36,12 +32,6 @@ func (f *CmdToolAggregateFlags) Init() {
 		"quiet", "q", false,
 		"quiet mode; suppress additional output.",
 	)
-}
-
-// CIDR represens a Classless Inter-Domain Routing structure.
-type CIDR struct {
-	IP      net.IP
-	Network *net.IPNet
 }
 
 // CmdToolAggregate is the common core logic for aggregating IPs, IP ranges and CIDRs.
@@ -178,59 +168,6 @@ func CmdToolAggregate(
 	}
 
 	return nil
-}
-
-// newCidr creates a newCidr CIDR structure.
-func newCidr(s string) *CIDR {
-	ip, ipnet, err := net.ParseCIDR(s)
-	if err != nil {
-		panic(err)
-	}
-	return &CIDR{
-		IP:      ip,
-		Network: ipnet,
-	}
-}
-
-func (c *CIDR) String() string {
-	return c.Network.String()
-}
-
-// MaskLen returns a network mask length.
-func (c *CIDR) MaskLen() uint32 {
-	i, _ := c.Network.Mask.Size()
-	return uint32(i)
-}
-
-// PrefixUint32 returns a prefix.
-func (c *CIDR) PrefixUint32() uint32 {
-	return binary.BigEndian.Uint32(c.IP.To4())
-}
-
-// Size returns a size of a CIDR range.
-func (c *CIDR) Size() int {
-	ones, bits := c.Network.Mask.Size()
-	return int(math.Pow(2, float64(bits-ones)))
-}
-
-// list returns a slice of sorted CIDR structures.
-func list(s []string) []*CIDR {
-	out := make([]*CIDR, 0)
-	for _, c := range s {
-		out = append(out, newCidr(c))
-	}
-	sort.Sort(cidrSort(out))
-	return out
-}
-
-type cidrSort []*CIDR
-
-func (s cidrSort) Len() int      { return len(s) }
-func (s cidrSort) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-
-func (s cidrSort) Less(i, j int) bool {
-	cmp := bytes.Compare(s[i].IP, s[j].IP)
-	return cmp < 0 || (cmp == 0 && s[i].MaskLen() < s[j].MaskLen())
 }
 
 // stripOverlapping returns a slice of CIDR structures with overlapping ranges

--- a/lib/cmd_tool_aggregate.go
+++ b/lib/cmd_tool_aggregate.go
@@ -215,7 +215,6 @@ func areAdjacent(r1, r2 net.IPNet) bool {
 	prefix1 := binary.BigEndian.Uint32(r1.IP.To4())
 	prefix2 := binary.BigEndian.Uint32(r2.IP.To4())
 
-	fmt.Println("prefix1, prefix2", prefix1, prefix2)
 	mask1, _ := r1.Mask.Size()
 	mask2, _ := r2.Mask.Size()
 
@@ -235,11 +234,15 @@ func combineAdjacent(cidrs []net.IPNet) []net.IPNet {
 	res := make([]net.IPNet, 0)
 
 	for i := 0; i < len(cidrs)-1; i++ {
+
 		if areAdjacent(cidrs[i], cidrs[i+1]) {
 			res = append(res, combineAdjacentCIDRs(cidrs[i], cidrs[i+1]))
 			i++
 		} else {
 			res = append(res, cidrs[i])
+			if i == len(cidrs)-2 {
+				res = append(res, cidrs[i+1])
+			}
 		}
 	}
 


### PR DESCRIPTION
In https://github.com/ipinfo/cli/issues/187, we identified that `ipinfo tool aggregate` does not work for adjacent CIDRs. 

Checking adjacency based on two conditions:
- prefixes have the same mask length,
- the second prefix is exactly one larger than the first prefix

This works for IPv4 only.