### PR TITLE
slight modification in scripts

### DIFF
--- a/cidr2ip/deb.sh
+++ b/cidr2ip/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -28,7 +23,11 @@ case $ARCH in
 esac
 
 curl -LO https://github.com/ipinfo/cli/releases/download/cidr2ip-${VSN}/cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/cidr2ip/deb.sh
+++ b/cidr2ip/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -23,7 +28,7 @@ case $ARCH in
 esac
 
 curl -LO https://github.com/ipinfo/cli/releases/download/cidr2ip-${VSN}/cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
 rm cidr2ip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/cidr2range/deb.sh
+++ b/cidr2range/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.2.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/cidr2range-${VSN}/cidr2range_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i cidr2range_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i cidr2range_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i cidr2range_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm cidr2range_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/cidr2range/deb.sh
+++ b/cidr2range/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.2.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/cidr2range-${VSN}/cidr2range_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i cidr2range_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i cidr2range_${VSN}_linux_${ARCH_NAME}.deb
 rm cidr2range_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/grepdomain/deb.sh
+++ b/grepdomain/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/grepdomain-${VSN}/grepdomain_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i grepdomain_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i grepdomain_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i grepdomain_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm grepdomain_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/grepdomain/deb.sh
+++ b/grepdomain/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/grepdomain-${VSN}/grepdomain_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i grepdomain_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i grepdomain_${VSN}_linux_${ARCH_NAME}.deb
 rm grepdomain_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/grepip/deb.sh
+++ b/grepip/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.2.3
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/grepip-${VSN}/grepip_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i grepip_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i grepip_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i grepip_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm grepip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/grepip/deb.sh
+++ b/grepip/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.2.3
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/grepip-${VSN}/grepip_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i grepip_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i grepip_${VSN}_linux_${ARCH_NAME}.deb
 rm grepip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/ipinfo/deb.sh
+++ b/ipinfo/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=3.3.0
 DEFAULT_ARCH=amd64
 
@@ -23,7 +28,7 @@ case $ARCH in
 esac
 
 curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-${VSN}/ipinfo_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i ipinfo_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i ipinfo_${VSN}_linux_${ARCH_NAME}.deb
 rm ipinfo_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/ipinfo/deb.sh
+++ b/ipinfo/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=3.3.0
 DEFAULT_ARCH=amd64
 
@@ -28,7 +23,11 @@ case $ARCH in
 esac
 
 curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-${VSN}/ipinfo_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i ipinfo_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i ipinfo_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i ipinfo_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm ipinfo_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/matchip/deb.sh
+++ b/matchip/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/matchip-${VSN}/matchip_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i matchip_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i matchip_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i matchip_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm matchip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/matchip/deb.sh
+++ b/matchip/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/matchip-${VSN}/matchip_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i matchip_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i matchip_${VSN}_linux_${ARCH_NAME}.deb
 rm matchip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/prips/deb.sh
+++ b/prips/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/prips-${VSN}/prips_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i prips_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i prips_${VSN}_linux_${ARCH_NAME}.deb
 rm prips_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/prips/deb.sh
+++ b/prips/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/prips-${VSN}/prips_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i prips_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i prips_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i prips_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm prips_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/randip/deb.sh
+++ b/randip/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.1.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/randip-${VSN}/randip_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i randip_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i randip_${VSN}_linux_${ARCH_NAME}.deb
 rm randip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/randip/deb.sh
+++ b/randip/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.1.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/randip-${VSN}/randip_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i randip_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i randip_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i randip_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm randip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/range2cidr/deb.sh
+++ b/range2cidr/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.3.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/range2cidr-${VSN}/range2cidr_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i range2cidr_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i range2cidr_${VSN}_linux_${ARCH_NAME}.deb
 rm range2cidr_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/range2cidr/deb.sh
+++ b/range2cidr/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.3.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/range2cidr-${VSN}/range2cidr_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i range2cidr_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i range2cidr_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i range2cidr_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm range2cidr_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/range2ip/deb.sh
+++ b/range2ip/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/range2ip-${VSN}/range2ip_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i range2ip_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i range2ip_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i range2ip_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm range2ip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/range2ip/deb.sh
+++ b/range2ip/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/range2ip-${VSN}/range2ip_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i range2ip_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i range2ip_${VSN}_linux_${ARCH_NAME}.deb
 rm range2ip_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/splitcidr/deb.sh
+++ b/splitcidr/deb.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root privileges. Please run it as root or with sudo." >&2
-    exit 1
-fi
-
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -27,7 +22,11 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/splitcidr-${VSN}/splitcidr_${VSN}_linux_${ARCH_NAME}.deb
-dpkg -i splitcidr_${VSN}_linux_${ARCH_NAME}.deb
+if command -v sudo >/dev/null 2>&1; then
+    sudo dpkg -i splitcidr_${VSN}_linux_${ARCH_NAME}.deb
+else
+    dpkg -i splitcidr_${VSN}_linux_${ARCH_NAME}.deb
+fi
 rm splitcidr_${VSN}_linux_${ARCH_NAME}.deb
 
 echo

--- a/splitcidr/deb.sh
+++ b/splitcidr/deb.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges. Please run it as root or with sudo." >&2
+    exit 1
+fi
+
 VSN=1.0.0
 DEFAULT_ARCH=amd64
 
@@ -22,7 +27,7 @@ case $ARCH in
         ;;
 esac
 curl -LO https://github.com/ipinfo/cli/releases/download/splitcidr-${VSN}/splitcidr_${VSN}_linux_${ARCH_NAME}.deb
-sudo dpkg -i splitcidr_${VSN}_linux_${ARCH_NAME}.deb
+dpkg -i splitcidr_${VSN}_linux_${ARCH_NAME}.deb
 rm splitcidr_${VSN}_linux_${ARCH_NAME}.deb
 
 echo


### PR DESCRIPTION
`deb.sh` scripts require root privileges to execute instead of using `sudo` directly in it.

Naming issue in `matchip`'s script is already fixed. A new release of the CLI and users updating to this new version would fix most of the issues occurring in a Pod environment.