### PR TITLE
cli prints error if free user filters out paid fields

### DIFF
--- a/ipinfo/cmd_ip.go
+++ b/ipinfo/cmd_ip.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/fatih/color"
 	"github.com/ipinfo/cli/lib/complete"
 	"github.com/ipinfo/cli/lib/complete/predict"
 	"github.com/ipinfo/go/v2/ipinfo"
 	"github.com/spf13/pflag"
-	"net"
 )
 
 var completionsIP = &complete.Command{
@@ -99,9 +100,10 @@ func cmdIP(ipStr string) error {
 	}
 
 	if len(fField) > 0 {
+		accessibleData, permissionsErr := checkTokenPermissions(data)
 		d := make(ipinfo.BatchCore, 1)
 		d[ipStr] = data
-		return outputFieldBatchCore(d, fField, false, false)
+		return outputFieldBatchCore(d, fField, false, false, WithAccessibleData(accessibleData), WithPermissionsError(permissionsErr))
 	}
 	if fJSON {
 		return outputJSON(data)

--- a/ipinfo/utils_output.go
+++ b/ipinfo/utils_output.go
@@ -652,7 +652,6 @@ func checkPremiumData(core ipinfo.BatchCore, dataType string) error {
 	for _, coreEntry := range core {
 		if coreEntry.ASN == nil && coreEntry.Company == nil && coreEntry.Privacy == nil && coreEntry.Abuse == nil && coreEntry.Domains == nil {
 			return ErrPermission
-			//return fmt.Errorf("this token doesn't have permissions to access %s data", dataType)
 		} else if coreEntry.ASN != nil && coreEntry.Company == nil && coreEntry.Privacy == nil && coreEntry.Abuse == nil && coreEntry.Domains == nil {
 			if dataType == "company" || dataType == "carrier" || dataType == "privacy" || dataType == "abuse" || dataType == "domains" {
 				return ErrPermission

--- a/vendor/github.com/ipinfo/go/v2/ipinfo/core.go
+++ b/vendor/github.com/ipinfo/go/v2/ipinfo/core.go
@@ -27,6 +27,7 @@ type Core struct {
 	Timezone        string          `json:"timezone,omitempty" csv:"timezone" yaml:"timezone,omitempty"`
 	ASN             *CoreASN        `json:"asn,omitempty" csv:"asn_,inline" yaml:"asn,omitempty"`
 	Company         *CoreCompany    `json:"company,omitempty" csv:"company_,inline" yaml:"company,omitempty"`
+	Carrier         *CoreCarrier    `json:"carrier,omitempty" csv:"carrier_,inline" yaml:"carrier,omitempty"`
 	Privacy         *CorePrivacy    `json:"privacy,omitempty" csv:"privacy_,inline" yaml:"privacy,omitempty"`
 	Abuse           *CoreAbuse      `json:"abuse,omitempty" csv:"abuse_,inline" yaml:"abuse,omitempty"`
 	Domains         *CoreDomains    `json:"domains,omitempty" csv:"domains_,inline" yaml:"domains,omitempty"`
@@ -46,6 +47,13 @@ type CoreCompany struct {
 	Name   string `json:"name" csv:"name"`
 	Domain string `json:"domain" csv:"domain"`
 	Type   string `json:"type" csv:"type"`
+}
+
+// CoreCarrier represents carrier data for the Core API.
+type CoreCarrier struct {
+	Name string `json:"name" csv:"name"`
+	MCC  string `json:"mcc" csv:"mcc"`
+	MNC  string `json:"mnc" csv:"mnc"`
 }
 
 // CorePrivacy represents privacy data for the Core API.
@@ -388,6 +396,22 @@ func (c *Client) GetIPCompany(ip net.IP) (*CoreCompany, error) {
 		return nil, err
 	}
 	return core.Company, nil
+}
+
+/* CARRIER */
+
+// GetIPCarrier returns the carrier details for the specified IP.
+func GetIPCarrier(ip net.IP) (*CoreCarrier, error) {
+	return DefaultClient.GetIPCarrier(ip)
+}
+
+// GetIPCarrier returns the carrier details for the specified IP.
+func (c *Client) GetIPCarrier(ip net.IP) (*CoreCarrier, error) {
+	core, err := c.GetIPInfo(ip)
+	if err != nil {
+		return nil, err
+	}
+	return core.Carrier, nil
 }
 
 /* PRIVACY */

--- a/vendor/github.com/ipinfo/go/v2/ipinfo/core.go
+++ b/vendor/github.com/ipinfo/go/v2/ipinfo/core.go
@@ -27,7 +27,6 @@ type Core struct {
 	Timezone        string          `json:"timezone,omitempty" csv:"timezone" yaml:"timezone,omitempty"`
 	ASN             *CoreASN        `json:"asn,omitempty" csv:"asn_,inline" yaml:"asn,omitempty"`
 	Company         *CoreCompany    `json:"company,omitempty" csv:"company_,inline" yaml:"company,omitempty"`
-	Carrier         *CoreCarrier    `json:"carrier,omitempty" csv:"carrier_,inline" yaml:"carrier,omitempty"`
 	Privacy         *CorePrivacy    `json:"privacy,omitempty" csv:"privacy_,inline" yaml:"privacy,omitempty"`
 	Abuse           *CoreAbuse      `json:"abuse,omitempty" csv:"abuse_,inline" yaml:"abuse,omitempty"`
 	Domains         *CoreDomains    `json:"domains,omitempty" csv:"domains_,inline" yaml:"domains,omitempty"`
@@ -47,13 +46,6 @@ type CoreCompany struct {
 	Name   string `json:"name" csv:"name"`
 	Domain string `json:"domain" csv:"domain"`
 	Type   string `json:"type" csv:"type"`
-}
-
-// CoreCarrier represents carrier data for the Core API.
-type CoreCarrier struct {
-	Name string `json:"name" csv:"name"`
-	MCC  string `json:"mcc" csv:"mcc"`
-	MNC  string `json:"mnc" csv:"mnc"`
 }
 
 // CorePrivacy represents privacy data for the Core API.
@@ -396,22 +388,6 @@ func (c *Client) GetIPCompany(ip net.IP) (*CoreCompany, error) {
 		return nil, err
 	}
 	return core.Company, nil
-}
-
-/* CARRIER */
-
-// GetIPCarrier returns the carrier details for the specified IP.
-func GetIPCarrier(ip net.IP) (*CoreCarrier, error) {
-	return DefaultClient.GetIPCarrier(ip)
-}
-
-// GetIPCarrier returns the carrier details for the specified IP.
-func (c *Client) GetIPCarrier(ip net.IP) (*CoreCarrier, error) {
-	core, err := c.GetIPInfo(ip)
-	if err != nil {
-		return nil, err
-	}
-	return core.Carrier, nil
 }
 
 /* PRIVACY */


### PR DESCRIPTION
The CLI prints an error message when a user with a token attempts to access paid data for which they do not have permission.

Before:
![Screenshot from 2024-03-01 12-44-00](https://github.com/ipinfo/cli/assets/55349478/8660afee-188d-4fb8-97fa-ff459e562c61)

After:
![Screenshot from 2024-03-01 12-44-29](https://github.com/ipinfo/cli/assets/55349478/8b0f4ce6-3de7-49f3-a286-021e344c644b)



If the token has access to every premium data but no carrier data is associated with the IP:
![Screenshot from 2024-03-01 12-45-16](https://github.com/ipinfo/cli/assets/55349478/e517fea1-42c5-45a9-baa5-81107d01b936)


About 6 types of paid data could be sent to the user depending on their token. These paid data include ASN, Company, Carrier, Privacy, Abuse and Domains. 

We have multiple price plans for the user behind the token:
- Free plan (no paid data is sent in the API response).
- Basic plan (user only receives ASN data).
- Standard plan (user receives ASN and Privacy data).
- Business plan (user receives all types of paid data, except carrier data, which depends on the specific IP address).

This information is taken from the [sample API responses for different price plans](https://ipinfo.io/pricing) 

