### PR TITLE
Release - ipinfo version 3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install ipinfo-cli
 OR to install the latest `amd64` version without automatic updates:
 
 ```bash
-curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.0/macos.sh | sh
+curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/macos.sh | sh
 ```
 
 ### Ubuntu PPA
@@ -43,14 +43,14 @@ _Note_: this is a one-time installation; updates are not automatic. Use the PPA
 for automatic updates.
 
 ```bash
-curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.0/deb.sh | sh
+curl -Ls https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/deb.sh | sh
 ```
 
 OR
 
 ```bash
-curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.0/ipinfo_3.3.0_linux_{arch}.deb
-sudo dpkg -i ipinfo_3.3.0_linux_{arch}.deb
+curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/ipinfo_3.3.1_linux_{arch}.deb
+sudo dpkg -i ipinfo_3.3.1_linux_{arch}.deb
 ```
 
 where `{arch}` can be 386, amd64, arm, or arm64.
@@ -73,7 +73,7 @@ makepkg -si
 _Note_: run powershell as administrator before executing this command.
 
 ```bash
-iwr -useb https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.0/windows.ps1 | iex
+iwr -useb https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/windows.ps1 | iex
 ```
 
 ### Scoop
@@ -85,7 +85,7 @@ scoop install ipinfo-cli
 ### Docker
 
 ```bash
-docker run --rm -it ipinfo/ipinfo:3.3.0
+docker run --rm -it ipinfo/ipinfo:3.3.1
 ```
 
 To save the CLI's config, add `-v "/path_to_config:/root/.config/ipinfo"`. For
@@ -93,7 +93,7 @@ example, the following command saves the config to the `ipinfo` directory in
 the current working directory.
 
 ```bash
-docker run --rm -it -v "$PWD/ipinfo:/root/.config/ipinfo" ipinfo/ipinfo:3.3.0
+docker run --rm -it -v "$PWD/ipinfo:/root/.config/ipinfo" ipinfo/ipinfo:3.3.1
 ```
 
 ### Using `go install`
@@ -145,12 +145,12 @@ After choosing a platform `PLAT` from above, run:
 
 ```bash
 # for Windows, use ".zip" instead of ".tar.gz"
-curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.0/ipinfo_3.3.0_${PLAT}.tar.gz
+curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/ipinfo_3.3.1_${PLAT}.tar.gz
 # OR
-wget https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.0/ipinfo_3.3.0_${PLAT}.tar.gz
+wget https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/ipinfo_3.3.1_${PLAT}.tar.gz
 
-tar -xvf ipinfo_3.3.0_${PLAT}.tar.gz
-sudo mv ipinfo_3.3.0_${PLAT} /usr/local/bin/ipinfo
+tar -xvf ipinfo_3.3.1_${PLAT}.tar.gz
+sudo mv ipinfo_3.3.1_${PLAT} /usr/local/bin/ipinfo
 ```
 
 ### Using `git`

--- a/ipinfo/CHANGELOG.md
+++ b/ipinfo/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 3.3.1
+
+- Added support for Windows ARM64.
+- Windows users can also install via Winget, Chocolatey, and Scoop.
+- Updated Ubuntu PPA source. New URL is https://ppa.ipinfo.net.
+- Added multiple arch support to PPA. These architectures are; i386, amd64, armhf, and arm64.
+- Fixed ipinfo tool aggregate not working properly for adjacent CIRDs.
+- Added some basic IP tools such as:
+  - is_loopback
+  - is_multicast
+  - is_unspecified
+  - is_global_unicast
+  - is_interface_local_multicast
+  - is_link_local_multicast
+  - is_link_local_unicast
+- Fixed some issues related to convenience scripts.
+
+## Pull Requests
+
+- [#192](https://github.com/ipinfo/cli/pull/192)
+- [#193](https://github.com/ipinfo/cli/pull/193)
+- [#203](https://github.com/ipinfo/cli/pull/203)
+- [#204](https://github.com/ipinfo/cli/pull/204)
+- [#205](https://github.com/ipinfo/cli/pull/205)
+- [#207](https://github.com/ipinfo/cli/pull/207)
+
 # 3.3.0
 
 - Support CIDRs & Ranges in `grepip`.
@@ -16,7 +42,7 @@
 - [#185](https://github.com/ipinfo/cli/pull/185)
 - [#190](https://github.com/ipinfo/cli/pull/190)
 
-# 3.3.0
+# 3.2.0
 
 * `ipinfo tool prefix` introduced with some misc. prefix tools. Currently supports following subcommands:
     - `addr` returns the base IP address of a prefix.

--- a/ipinfo/deb.sh
+++ b/ipinfo/deb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VSN=3.3.0
+VSN=3.3.1
 DEFAULT_ARCH=amd64
 
 ARCH=$(uname -m)

--- a/ipinfo/macos.sh
+++ b/ipinfo/macos.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VSN=3.3.0
+VSN=3.3.1
 PLAT=darwin_amd64
 
 curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-${VSN}/ipinfo_${VSN}_${PLAT}.tar.gz

--- a/ipinfo/main.go
+++ b/ipinfo/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var progBase = filepath.Base(os.Args[0])
-var version = "3.3.0"
+var version = "3.3.1"
 
 // global flags.
 var fHelp bool

--- a/ipinfo/windows.ps1
+++ b/ipinfo/windows.ps1
@@ -1,4 +1,4 @@
-$VSN = "3.3.0"
+$VSN = "3.3.1"
 
 # build the filename for the Zip archive and exe file
 $FileName = "ipinfo_$($VSN)_windows_amd64"


### PR DESCRIPTION
Release summary:
- Added support for Windows ARM64.
- Windows users can also install via Winget, Chocolatey, and Scoop.
- Updated Ubuntu PPA source. New URL is https://ppa.ipinfo.net.
- Added multiple arch support to PPA. These architectures are; i386, amd64, armhf, and arm64.
- Fixed ipinfo tool aggregate not working properly for adjacent CIRDs.
- Added some basic IP tools such as:
  - is_loopback
  - is_multicast
  - is_unspecified
  - is_global_unicast
  - is_interface_local_multicast
  - is_link_local_multicast
  - is_link_local_unicast
- Fixed some issues related to convenience scripts.