### PR TITLE
Quote all instances of `rm $0`

### DIFF
--- a/cidr2ip/deb.sh
+++ b/cidr2ip/deb.sh
@@ -34,5 +34,5 @@ echo
 echo 'You can now run `cidr2ip`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/cidr2range/deb.sh
+++ b/cidr2range/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `cidr2range`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/grepdomain/deb.sh
+++ b/grepdomain/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `grepdomain`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/grepip/deb.sh
+++ b/grepip/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `grepip`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/ipinfo/deb.sh
+++ b/ipinfo/deb.sh
@@ -34,5 +34,5 @@ echo
 echo 'You can now run `ipinfo`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/matchip/deb.sh
+++ b/matchip/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `matchip`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/prips/deb.sh
+++ b/prips/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `prips`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/randip/deb.sh
+++ b/randip/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `randip`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/range2cidr/deb.sh
+++ b/range2cidr/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `range2cidr`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/range2ip/deb.sh
+++ b/range2ip/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `range2ip`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi

--- a/splitcidr/deb.sh
+++ b/splitcidr/deb.sh
@@ -33,5 +33,5 @@ echo
 echo 'You can now run `splitcidr`'.
 
 if [ -f "$0" ]; then
-    rm $0
+    rm "$0"
 fi


### PR DESCRIPTION
This prevents accidental deletions on invocation paths with whitespace.
Additionally, it makes the `deb.sh` scripts consistent with the `macos.sh` scripts (that already have these statements quoted).