### PR TITLE
Quote all instances of DIR and ROOT

### DIFF
--- a/cidr2ip/build-all-platforms.sh
+++ b/cidr2ip/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "cidr2ip" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "cidr2ip" $VSN

--- a/cidr2ip/build.sh
+++ b/cidr2ip/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "cidr2ip"
+"$ROOT"/scripts/build.sh "cidr2ip"

--- a/cidr2ip/docker.sh
+++ b/cidr2ip/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "cidr2ip" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "cidr2ip" $VSN $RELEASE

--- a/cidr2ip/release.sh
+++ b/cidr2ip/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "cidr2ip" $VSN
+"$ROOT"/scripts/release.sh "cidr2ip" $VSN

--- a/cidr2range/build-all-platforms.sh
+++ b/cidr2range/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "cidr2range" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "cidr2range" $VSN

--- a/cidr2range/build.sh
+++ b/cidr2range/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "cidr2range"
+"$ROOT"/scripts/build.sh "cidr2range"

--- a/cidr2range/docker.sh
+++ b/cidr2range/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "cidr2range" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "cidr2range" $VSN $RELEASE

--- a/cidr2range/release.sh
+++ b/cidr2range/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "cidr2range" $VSN
+"$ROOT"/scripts/release.sh "cidr2range" $VSN

--- a/grepdomain/build-all-platforms.sh
+++ b/grepdomain/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "grepdomain" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "grepdomain" $VSN

--- a/grepdomain/build.sh
+++ b/grepdomain/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "grepdomain"
+"$ROOT"/scripts/build.sh "grepdomain"

--- a/grepdomain/docker.sh
+++ b/grepdomain/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "grepdomain" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "grepdomain" $VSN $RELEASE

--- a/grepdomain/release.sh
+++ b/grepdomain/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "grepdomain" $VSN
+"$ROOT"/scripts/release.sh "grepdomain" $VSN

--- a/grepip/build-all-platforms.sh
+++ b/grepip/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "grepip" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "grepip" $VSN

--- a/grepip/build.sh
+++ b/grepip/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "grepip"
+"$ROOT"/scripts/build.sh "grepip"

--- a/grepip/docker.sh
+++ b/grepip/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "grepip" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "grepip" $VSN $RELEASE

--- a/grepip/release.sh
+++ b/grepip/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "grepip" $VSN
+"$ROOT"/scripts/release.sh "grepip" $VSN

--- a/ipinfo/build-all-platforms.sh
+++ b/ipinfo/build-all-platforms.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 LINUX_ONLY=$2
 
-$ROOT/scripts/build-all-platforms.sh "ipinfo" $VSN $LINUX_ONLY
+"$ROOT"/scripts/build-all-platforms.sh "ipinfo" $VSN $LINUX_ONLY

--- a/ipinfo/build.sh
+++ b/ipinfo/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "ipinfo"
+"$ROOT"/scripts/build.sh "ipinfo"

--- a/ipinfo/docker.sh
+++ b/ipinfo/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "ipinfo" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "ipinfo" $VSN $RELEASE

--- a/ipinfo/release.sh
+++ b/ipinfo/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "ipinfo" $VSN
+"$ROOT"/scripts/release.sh "ipinfo" $VSN

--- a/matchip/build-all-platforms.sh
+++ b/matchip/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "matchip" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "matchip" $VSN

--- a/matchip/build.sh
+++ b/matchip/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "matchip"
+"$ROOT"/scripts/build.sh "matchip"

--- a/matchip/docker.sh
+++ b/matchip/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "matchip" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "matchip" $VSN $RELEASE

--- a/matchip/release.sh
+++ b/matchip/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "matchip" $VSN
+"$ROOT"/scripts/release.sh "matchip" $VSN

--- a/prips/build-all-platforms.sh
+++ b/prips/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "prips" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "prips" $VSN

--- a/prips/build.sh
+++ b/prips/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "prips"
+"$ROOT"/scripts/build.sh "prips"

--- a/prips/docker.sh
+++ b/prips/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "prips" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "prips" $VSN $RELEASE

--- a/prips/release.sh
+++ b/prips/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "prips" $VSN
+"$ROOT"/scripts/release.sh "prips" $VSN

--- a/randip/build-all-platforms.sh
+++ b/randip/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "randip" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "randip" $VSN

--- a/randip/build.sh
+++ b/randip/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "randip"
+"$ROOT"/scripts/build.sh "randip"

--- a/randip/docker.sh
+++ b/randip/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "randip" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "randip" $VSN $RELEASE

--- a/randip/release.sh
+++ b/randip/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "randip" $VSN
+"$ROOT"/scripts/release.sh "randip" $VSN

--- a/range2cidr/build-all-platforms.sh
+++ b/range2cidr/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "range2cidr" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "range2cidr" $VSN

--- a/range2cidr/build.sh
+++ b/range2cidr/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "range2cidr"
+"$ROOT"/scripts/build.sh "range2cidr"

--- a/range2cidr/docker.sh
+++ b/range2cidr/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "range2cidr" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "range2cidr" $VSN $RELEASE

--- a/range2cidr/release.sh
+++ b/range2cidr/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "range2cidr" $VSN
+"$ROOT"/scripts/release.sh "range2cidr" $VSN

--- a/range2ip/build-all-platforms.sh
+++ b/range2ip/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "range2ip" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "range2ip" $VSN

--- a/range2ip/build.sh
+++ b/range2ip/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "range2ip"
+"$ROOT"/scripts/build.sh "range2ip"

--- a/range2ip/docker.sh
+++ b/range2ip/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "range2ip" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "range2ip" $VSN $RELEASE

--- a/range2ip/release.sh
+++ b/range2ip/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "range2ip" $VSN
+"$ROOT"/scripts/release.sh "range2ip" $VSN

--- a/scripts/build-all-platforms.sh
+++ b/scripts/build-all-platforms.sh
@@ -5,8 +5,8 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 CLI=$1
 VSN=$2
@@ -68,8 +68,8 @@ do
 
     echo "building ${output}"
     GOOS=$os GOARCH=$arch go build                                            \
-        -o $ROOT/build/${output}                                              \
-        $ROOT/${CLI}
+        -o "$ROOT"/build/${output}                                              \
+        "$ROOT"/${CLI}
 done
 
 wait

--- a/scripts/build-archive-all.sh
+++ b/scripts/build-archive-all.sh
@@ -5,8 +5,8 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 CLI=$1
 VSN=$2
@@ -28,11 +28,11 @@ if [ ! -d "$CLI" ]; then
 fi
 
 # build
-rm -f $ROOT/build/${CLI}_${VSN}*
-$ROOT/${CLI}/build-all-platforms.sh "$VSN" "$LINUX_ONLY"
+rm -f "$ROOT"/build/${CLI}_${VSN}*
+"$ROOT"/${CLI}/build-all-platforms.sh "$VSN" "$LINUX_ONLY"
 
 # archive
-cd $ROOT/build
+cd "$ROOT"/build
 for t in ${CLI}_${VSN}_* ; do
     if [[ $t == ${CLI}_*_windows_* ]]; then
         zip -q ${t/.exe/.zip} $t

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,11 +2,11 @@
 
 # Build binary for cli $1.
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 CLI=$1
 
 go build                                                                      \
-    -o $ROOT/build/${CLI}                                                     \
-    $ROOT/${CLI}
+    -o "$ROOT"/build/${CLI}                                                     \
+    "$ROOT"/${CLI}

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -5,15 +5,15 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 CLI=$1
 VERSION=$2
 
 found=0
 
-cat $ROOT/${CLI}/CHANGELOG.md | while IFS= read "line"; do
+cat "$ROOT"/${CLI}/CHANGELOG.md | while IFS= read "line"; do
     # Find the version heading
     if [ $found -eq 0 ] && (echo "$line" | grep -q -E "^(#|##) $VERSION$"); then
         found=1

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -7,8 +7,8 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 CLI=$1
 VSN=$2
@@ -27,14 +27,14 @@ fi
 # build
 # disable CGO to make static binary
 CGO_ENABLED=0 go build                                                        \
-    -o $ROOT/${CLI}/build/$CLI                                                \
-    $ROOT/${CLI}
+    -o "$ROOT"/${CLI}/build/$CLI                                                \
+    "$ROOT"/${CLI}
 
 # docker container
-docker build --tag ipinfo/$CLI:$VSN $ROOT/$CLI/
+docker build --tag ipinfo/$CLI:$VSN "$ROOT"/$CLI/
 
 # cleanup 
-rm -r $ROOT/$CLI/build
+rm -r "$ROOT"/$CLI/build
 
 if [ "$RELEASE" = "-r" ] || [ "$RELEASE" = "--release" ]; then
     # push on docker hub

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 # Format code in project.
 
 gofmt -w                                                                      \
-    $ROOT/lib                                                                 \
-    $ROOT/ipinfo                                                              \
-    $ROOT/grepip                                                              \
-    $ROOT/grepdomain                                                          \
-    $ROOT/matchip                                                             \
-    $ROOT/prips                                                               \
-    $ROOT/cidr2range                                                          \
-    $ROOT/range2cidr                                                          \
-    $ROOT/range2ip                                                            \
-    $ROOT/cidr2ip                                                             \
-    $ROOT/splitcidr                                                           \
-    $ROOT/randip
+    "$ROOT"/lib                                                                 \
+    "$ROOT"/ipinfo                                                              \
+    "$ROOT"/grepip                                                              \
+    "$ROOT"/grepdomain                                                          \
+    "$ROOT"/matchip                                                             \
+    "$ROOT"/prips                                                               \
+    "$ROOT"/cidr2range                                                          \
+    "$ROOT"/range2cidr                                                          \
+    "$ROOT"/range2ip                                                            \
+    "$ROOT"/cidr2ip                                                             \
+    "$ROOT"/splitcidr                                                           \
+    "$ROOT"/randip

--- a/scripts/release-ppa.sh
+++ b/scripts/release-ppa.sh
@@ -2,8 +2,8 @@
 
 # Build and to upload IPinfo offical PPA.
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 KEY=$2
@@ -19,11 +19,11 @@ if [ -z "$KEY" ]; then
 fi
 
 # building the package
-cd $ROOT
+cd "$ROOT"
 debuild -us -uc -S -d
 
 # signing the package
-cd $ROOT/..
+cd "$ROOT"/..
 debsign -k $KEY ipinfo_${VSN}.dsc ipinfo_${VSN}_source.changes
 
 # uploading the package to ppa

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 CLI=$1
 VSN=$2
@@ -26,15 +26,15 @@ if [ ! -d "$CLI" ]; then
 fi
 
 # build
-$ROOT/scripts/build-archive-all.sh "$CLI" "$VSN"
+"$ROOT"/scripts/build-archive-all.sh "$CLI" "$VSN"
 
 # release
 gh release create ${CLI}-${VSN}                                               \
     -R ipinfo/cli                                                             \
     -t "${CLI}-${VSN}"                                                        \
-    $ROOT/build/${CLI}_${VSN}*.tar.gz                                         \
-    $ROOT/build/${CLI}_${VSN}*.zip                                            \
-    $ROOT/build/${CLI}_${VSN}*.deb                                            \
-    $ROOT/${CLI}/macos.sh                                                     \
-    $ROOT/${CLI}/windows.ps1                                                  \
-    $ROOT/${CLI}/deb.sh
+    "$ROOT"/build/${CLI}_${VSN}*.tar.gz                                         \
+    "$ROOT"/build/${CLI}_${VSN}*.zip                                            \
+    "$ROOT"/build/${CLI}_${VSN}*.deb                                            \
+    "$ROOT"/${CLI}/macos.sh                                                     \
+    "$ROOT"/${CLI}/windows.ps1                                                  \
+    "$ROOT"/${CLI}/deb.sh

--- a/splitcidr/build-all-platforms.sh
+++ b/splitcidr/build-all-platforms.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/build-all-platforms.sh "splitcidr" $VSN
+"$ROOT"/scripts/build-all-platforms.sh "splitcidr" $VSN

--- a/splitcidr/build.sh
+++ b/splitcidr/build.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
-$ROOT/scripts/build.sh "splitcidr"
+"$ROOT"/scripts/build.sh "splitcidr"

--- a/splitcidr/docker.sh
+++ b/splitcidr/docker.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 RELEASE=$2
 
-$ROOT/scripts/docker.sh "splitcidr" $VSN $RELEASE
+"$ROOT"/scripts/docker.sh "splitcidr" $VSN $RELEASE

--- a/splitcidr/release.sh
+++ b/splitcidr/release.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-DIR=`dirname $0`
-ROOT=$DIR/..
+DIR=`dirname "$0"`
+ROOT="$DIR"/..
 
 VSN=$1
 
-$ROOT/scripts/release.sh "splitcidr" $VSN
+"$ROOT"/scripts/release.sh "splitcidr" $VSN


### PR DESCRIPTION
They are derived from $0, so not quoting them can break scripts if $0 contains whitespace.